### PR TITLE
Add support for FreeBSD (berkeley-unix)

### DIFF
--- a/doom-modeline-now-playing-playerctl.el
+++ b/doom-modeline-now-playing-playerctl.el
@@ -62,10 +62,10 @@ As well as a number of functions:
 
 (defclass doom-modeline-now-playing-playerctl (doom-modeline-now-playing-provider)
   ((name :initform "playerctl")
-   (supported-p :initform (lambda ()
-                           (and (eq system-type 'gnu/linux)
-                                (executable-find "playerctl")))))
-  "Linux playerctl provider implementation.")
+   (supported-p :initform (lambda () 
+                            (and (memq system-type '(gnu/linux berkeley-unix))
+                                 (executable-find "playerctl")))))
+  "Linux/Freebsd playerctl provider implementation.")
 
 (cl-defmethod doom-modeline-now-playing-provider-get-info ((provider doom-modeline-now-playing-playerctl))
   "Get playerctl information for PROVIDER."

--- a/doom-modeline-now-playing-playerctl.el
+++ b/doom-modeline-now-playing-playerctl.el
@@ -62,10 +62,10 @@ As well as a number of functions:
 
 (defclass doom-modeline-now-playing-playerctl (doom-modeline-now-playing-provider)
   ((name :initform "playerctl")
-   (supported-p :initform (lambda () 
+   (supported-p :initform (lambda ()
                             (and (memq system-type '(gnu/linux berkeley-unix bsd))
                                  (executable-find "playerctl")))))
-  "playerctl provider implementation for Linux and BSD systems.")
+  "Playerctl provider implementation.")
 
 (cl-defmethod doom-modeline-now-playing-provider-get-info ((provider doom-modeline-now-playing-playerctl))
   "Get playerctl information for PROVIDER."
@@ -89,9 +89,9 @@ As well as a number of functions:
 (cl-defmethod doom-modeline-now-playing-provider-play-pause ((provider doom-modeline-now-playing-playerctl) _player)
   "Toggle playerctl playback for PROVIDER."
   (let* ((ignore-arg (if doom-modeline-now-playing-playerctl-ignored-players
-                             (format "--ignore-player=%s"
-                                     (mapconcat #'identity doom-modeline-now-playing-playerctl-ignored-players ","))
-                           ""))
+                         (format "--ignore-player=%s"
+                                 (mapconcat #'identity doom-modeline-now-playing-playerctl-ignored-players ","))
+                       ""))
          (command (format "playerctl %s play-pause" ignore-arg)))
     (start-process-shell-command "playerctl" nil command)))
 

--- a/doom-modeline-now-playing-playerctl.el
+++ b/doom-modeline-now-playing-playerctl.el
@@ -65,7 +65,7 @@ As well as a number of functions:
    (supported-p :initform (lambda () 
                             (and (memq system-type '(gnu/linux berkeley-unix bsd))
                                  (executable-find "playerctl")))))
-  "Linux/Freebsd playerctl provider implementation.")
+  "playerctl provider implementation for Linux and BSD systems.")
 
 (cl-defmethod doom-modeline-now-playing-provider-get-info ((provider doom-modeline-now-playing-playerctl))
   "Get playerctl information for PROVIDER."

--- a/doom-modeline-now-playing-playerctl.el
+++ b/doom-modeline-now-playing-playerctl.el
@@ -63,7 +63,7 @@ As well as a number of functions:
 (defclass doom-modeline-now-playing-playerctl (doom-modeline-now-playing-provider)
   ((name :initform "playerctl")
    (supported-p :initform (lambda () 
-                            (and (memq system-type '(gnu/linux berkeley-unix))
+                            (and (memq system-type '(gnu/linux berkeley-unix bsd))
                                  (executable-find "playerctl")))))
   "Linux/Freebsd playerctl provider implementation.")
 

--- a/doom-modeline-now-playing.el
+++ b/doom-modeline-now-playing.el
@@ -78,19 +78,18 @@ This will be automatically initialized when first accessed."
 
 (defun doom-modeline-now-playing--get-provider ()
   "Get or initialize the current provider."
-  (unless doom-modeline-now-playing-current-provider
-    (setq doom-modeline-now-playing-current-provider
-          (cond
-           ((and (memq system-type '(gnu/linux berkeley-unix bsd))
-                 (require 'doom-modeline-now-playing-playerctl nil t))
-            (doom-modeline-now-playing-playerctl-create))
-           ((eq system-type 'darwin)
-            (or (and (executable-find "media-control")
-                     (require 'doom-modeline-now-playing-media-control nil t)
-                     (doom-modeline-now-playing-media-control-create))
-                (and (require 'doom-modeline-now-playing-osascript nil t)
-                     (doom-modeline-now-playing-osascript-create)))))))
-  doom-modeline-now-playing-current-provider)
+  (or doom-modeline-now-playing-current-provider
+      (setq doom-modeline-now-playing-current-provider
+            (cond
+             ((and (memq system-type '(gnu/linux berkeley-unix bsd))
+                   (require 'doom-modeline-now-playing-playerctl nil t))
+              (doom-modeline-now-playing-playerctl-create))
+             ((eq system-type 'darwin)
+              (if (and (executable-find "media-control")
+                       (require 'doom-modeline-now-playing-media-control nil t))
+                  (doom-modeline-now-playing-media-control-create)
+                (when (require 'doom-modeline-now-playing-osascript nil t)
+                  (doom-modeline-now-playing-osascript-create))))))))
 
 ;;
 ;; Core functionality

--- a/doom-modeline-now-playing.el
+++ b/doom-modeline-now-playing.el
@@ -81,7 +81,7 @@ This will be automatically initialized when first accessed."
   (unless doom-modeline-now-playing-current-provider
     (setq doom-modeline-now-playing-current-provider
           (cond
-           ((and (memq system-type '(gnu/linux berkeley-unix))
+           ((and (memq system-type '(gnu/linux berkeley-unix bsd))
                  (require 'doom-modeline-now-playing-playerctl nil t))
             (doom-modeline-now-playing-playerctl-create))
            ((eq system-type 'darwin)

--- a/doom-modeline-now-playing.el
+++ b/doom-modeline-now-playing.el
@@ -85,11 +85,11 @@ This will be automatically initialized when first accessed."
                  (require 'doom-modeline-now-playing-playerctl nil t))
             (doom-modeline-now-playing-playerctl-create))
            ((eq system-type 'darwin)
-            (if (and (executable-find "media-control")
-                     (require 'doom-modeline-now-playing-media-control nil t))
-                (doom-modeline-now-playing-media-control-create)
-              (when (require 'doom-modeline-now-playing-osascript nil t)
-                (doom-modeline-now-playing-osascript-create)))))))
+            (or (and (executable-find "media-control")
+                     (require 'doom-modeline-now-playing-media-control nil t)
+                     (doom-modeline-now-playing-media-control-create))
+                (and (require 'doom-modeline-now-playing-osascript nil t)
+                     (doom-modeline-now-playing-osascript-create)))))))
   doom-modeline-now-playing-current-provider)
 
 ;;

--- a/doom-modeline-now-playing.el
+++ b/doom-modeline-now-playing.el
@@ -81,7 +81,7 @@ This will be automatically initialized when first accessed."
   (unless doom-modeline-now-playing-current-provider
     (setq doom-modeline-now-playing-current-provider
           (cond
-           ((and (eq system-type 'gnu/linux)
+           ((and (memq system-type '(gnu/linux berkeley-unix))
                  (require 'doom-modeline-now-playing-playerctl nil t))
             (doom-modeline-now-playing-playerctl-create))
            ((eq system-type 'darwin)
@@ -89,7 +89,7 @@ This will be automatically initialized when first accessed."
                      (require 'doom-modeline-now-playing-media-control nil t))
                 (doom-modeline-now-playing-media-control-create)
               (when (require 'doom-modeline-now-playing-osascript nil t)
-                (doom-modeline-now-playing-osascript)))))))
+                (doom-modeline-now-playing-osascript-create)))))))
   doom-modeline-now-playing-current-provider)
 
 ;;


### PR DESCRIPTION
This adds berkeley-unix to the system-type checks in both the core provider logic and the initialization gatekeeper